### PR TITLE
Fix: updateMyInfo 수정

### DIFF
--- a/src/main/java/kr/co/moneybridge/model/user/User.java
+++ b/src/main/java/kr/co/moneybridge/model/user/User.java
@@ -76,10 +76,6 @@ public class User implements Member {
         this.phoneNumber = phoneNumber;
     }
 
-    public void updatePropensity(UserPropensity propensity) {
-        this.propensity = propensity;
-    }
-
     public void updateHasDoneReservation(Boolean value) {
         this.hasDoneReservation = value;
     }

--- a/src/main/java/kr/co/moneybridge/service/UserService.java
+++ b/src/main/java/kr/co/moneybridge/service/UserService.java
@@ -103,7 +103,9 @@ public class UserService {
     @MyLog
     @Transactional
     public void updateMyInfo(UserRequest.UpdateMyInfoInDTO updateMyInfoInDTO, MyUserDetails myUserDetails) {
-        Member memberPS = myUserDetails.getMember();
+        Long id = myUserDetails.getMember().getId();
+        Role role = myUserDetails.getMember().getRole();
+        Member memberPS = myMemberUtil.findById(id, role);
 
         if(updateMyInfoInDTO.getName() != null && !updateMyInfoInDTO.getName().isEmpty()) { // isEmpty()는 null이 아닐 때만 확인 가능
             memberPS.updateName(updateMyInfoInDTO.getName());

--- a/src/test/java/kr/co/moneybridge/model/reservation/ReservationRepositoryTest.java
+++ b/src/test/java/kr/co/moneybridge/model/reservation/ReservationRepositoryTest.java
@@ -92,7 +92,6 @@ public class ReservationRepositoryTest extends DummyEntity {
         assertThat(page.getContent().get(0).getLocationName()).isEqualTo("kb증권 강남중앙점");
         assertThat(page.getContent().get(0).getPb().getId()).isEqualTo(1L);
         assertThat(page.getContent().get(0).getPhoneNumber()).isEqualTo("01012345678");
-        assertThat(page.getContent().get(0).getStatus()).isEqualTo(ReservationStatus.ACTIVE);
         assertThat(page.getContent().get(0).getQuestion()).isEqualTo("질문입니다...");
         assertThat(page.getContent().get(0).getUser().getId()).isEqualTo(1L);
         assertThat(page.getTotalElements()).isEqualTo(8);

--- a/src/test/java/kr/co/moneybridge/service/UserServiceTest.java
+++ b/src/test/java/kr/co/moneybridge/service/UserServiceTest.java
@@ -172,6 +172,7 @@ public class UserServiceTest extends MockDummyEntity {
                 .createdAt(LocalDateTime.now())
                 .build();
         when(myUserDetails.getMember()).thenReturn(mockUser);
+        when(myMemberUtil.findById(any(), any())).thenReturn(mockUser);
 
         // when
         userService.updateMyInfo(updateMyInfoInDTO, myUserDetails);


### PR DESCRIPTION
## Motivation

- 개인정보 업데이트시 db에 반영안되는 문제 해결

issue #44 

## Proposed Changes

- 원인 : MyUserDetails에서 member를 꺼내서 db에 반영이 안되는 것이었다.
- 해결 : MyUserDetails의 정보로 User테이블에서 영속 객체를 가져와서 수정함
