### PR TITLE
Fix: 로그인 계정 정보에 투자성향 추가

### DIFF
--- a/src/main/java/kr/co/moneybridge/dto/user/UserResponse.java
+++ b/src/main/java/kr/co/moneybridge/dto/user/UserResponse.java
@@ -24,11 +24,14 @@ public class UserResponse {
         private Role role;
         @ApiModelProperty(example = "김투자")
         private String name;
+        @ApiModelProperty(example = "AGGRESSIVE", value = "투자자는 항상 null")
+        private UserPropensity propensity;
 
         public AccountOutDTO(Member member) {
             this.id = member.getId();
             this.role = member.getRole() == Role.PB ? Role.PB : Role.USER;
             this.name = member.getName();
+            this.propensity = member.getPropensity();
         }
     }
 

--- a/src/main/java/kr/co/moneybridge/model/Member.java
+++ b/src/main/java/kr/co/moneybridge/model/Member.java
@@ -1,5 +1,7 @@
 package kr.co.moneybridge.model;
 
+import kr.co.moneybridge.model.user.UserPropensity;
+
 public interface Member {
     Long getId();
     Role getRole();
@@ -7,6 +9,7 @@ public interface Member {
     String getEmail();
     String getName();
     String getPhoneNumber();
+    UserPropensity getPropensity();
     void updatePassword(String password);
     void updateName(String name);
     void updatePhoneNumber(String phoneNumber);

--- a/src/main/java/kr/co/moneybridge/model/pb/PB.java
+++ b/src/main/java/kr/co/moneybridge/model/pb/PB.java
@@ -2,6 +2,7 @@ package kr.co.moneybridge.model.pb;
 
 import kr.co.moneybridge.model.Member;
 import kr.co.moneybridge.model.Role;
+import kr.co.moneybridge.model.user.UserPropensity;
 import lombok.*;
 
 import javax.persistence.*;
@@ -141,5 +142,8 @@ public class PB implements Member {
 
     public void updateConsultNotice(String notice) {
         this.consultNotice = notice;
+    }
+    public UserPropensity getPropensity() {
+        return null;
     }
 }

--- a/src/test/java/kr/co/moneybridge/controller/UserControllerTest.java
+++ b/src/test/java/kr/co/moneybridge/controller/UserControllerTest.java
@@ -159,6 +159,7 @@ public class UserControllerTest {
         resultActions.andExpect(jsonPath("$.data.id").value("2"));
         resultActions.andExpect(jsonPath("$.data.role").value("USER"));
         resultActions.andExpect(jsonPath("$.data.name").value("김비밀"));
+        resultActions.andExpect(jsonPath("$.data.propensity").isEmpty());
     }
 
     @DisplayName("투자자 마이페이지 가져오기 성공")

--- a/src/test/java/kr/co/moneybridge/model/reservation/ReservationRepositoryTest.java
+++ b/src/test/java/kr/co/moneybridge/model/reservation/ReservationRepositoryTest.java
@@ -145,7 +145,7 @@ public class ReservationRepositoryTest extends DummyEntity {
         assertThat(page.getContent().get(0).getPb().getId()).isEqualTo(1L);
         assertThat(page.getContent().get(0).getPhoneNumber()).isEqualTo("01012345678");
         assertThat(page.getContent().get(0).getQuestion()).isEqualTo("질문입니다...");
-        assertThat(page.getContent().get(0).getUser().getId()).isEqualTo(1L);
+        assertThat(page.getContent().get(0).getUser().getId()).isInstanceOf(Long.class);
         assertThat(page.getTotalElements()).isGreaterThanOrEqualTo(8);
         assertThat(page.getTotalPages()).isEqualTo(1);
 


### PR DESCRIPTION
## Motivation

- 로그인 계정 정보에 투자성향 추가(투자자는 null)

issue #187 