### PR TITLE
Feat: backlog 관리자가 강제 게시글(콘텐츠, 댓글, 대댓글) 삭제 API

### DIFF
--- a/src/main/java/kr/co/moneybridge/controller/BackOfficeController.java
+++ b/src/main/java/kr/co/moneybridge/controller/BackOfficeController.java
@@ -18,6 +18,33 @@ import org.springframework.web.bind.annotation.*;
 public class BackOfficeController {
     private final BackOfficeService backOfficeService;
 
+    // 콘텐츠 강제 삭제
+    @MyLog
+    @SwaggerResponses.DeleteRereply
+    @DeleteMapping("/admin/rereply/{id}")
+    public ResponseDTO deleteRereply(@PathVariable Long id) {
+        backOfficeService.deleteRereply(id);
+        return new ResponseDTO<>();
+    }
+
+    // 댓글 강제 삭제
+    @MyLog
+    @SwaggerResponses.DeleteReply
+    @DeleteMapping("/admin/reply/{id}")
+    public ResponseDTO deleteReply(@PathVariable Long id) {
+        backOfficeService.deleteReply(id);
+        return new ResponseDTO<>();
+    }
+
+    // 콘텐츠 강제 삭제
+    @MyLog
+    @SwaggerResponses.DeleteBoard
+    @DeleteMapping("/admin/board/{id}")
+    public ResponseDTO deleteBoard(@PathVariable Long id) {
+        backOfficeService.deleteBoard(id);
+        return new ResponseDTO<>();
+    }
+
     // 상담 현황 페이지 전체 가져오기
     @MyLog
     @SwaggerResponses.GetReservations

--- a/src/main/java/kr/co/moneybridge/controller/BackOfficeController.java
+++ b/src/main/java/kr/co/moneybridge/controller/BackOfficeController.java
@@ -18,12 +18,12 @@ import org.springframework.web.bind.annotation.*;
 public class BackOfficeController {
     private final BackOfficeService backOfficeService;
 
-    // 콘텐츠 강제 삭제
+    // 대댓글 강제 삭제
     @MyLog
     @SwaggerResponses.DeleteRereply
     @DeleteMapping("/admin/rereply/{id}")
-    public ResponseDTO deleteRereply(@PathVariable Long id) {
-        backOfficeService.deleteRereply(id);
+    public ResponseDTO deleteReReply(@PathVariable Long id) {
+        backOfficeService.deleteReReply(id);
         return new ResponseDTO<>();
     }
 

--- a/src/main/java/kr/co/moneybridge/core/annotation/SwaggerResponses.java
+++ b/src/main/java/kr/co/moneybridge/core/annotation/SwaggerResponses.java
@@ -57,6 +57,63 @@ public class SwaggerResponses {
     public @interface DefaultApiResponses {
     }
 
+    @ApiOperation(value = "콘텐츠 강제 삭제")
+    @ApiResponses({
+            @ApiResponse(code = 400,
+                    message = BAD_REQUEST),
+            @ApiResponse(code = 401,
+                    message = UNAUTHORIZED),
+            @ApiResponse(code = 403,
+                    message = FORBIDDEN),
+            @ApiResponse(code = 500,
+                    message = INTERNAL_SERVER_ERROR)
+    })
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "id", example = "1", value = "rereply(대댓글) id")})
+    @ResponseStatus(HttpStatus.OK)
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface DeleteRereply {
+    }
+
+    @ApiOperation(value = "댓글 강제 삭제")
+    @ApiResponses({
+            @ApiResponse(code = 400,
+                    message = BAD_REQUEST),
+            @ApiResponse(code = 401,
+                    message = UNAUTHORIZED),
+            @ApiResponse(code = 403,
+                    message = FORBIDDEN),
+            @ApiResponse(code = 500,
+                    message = INTERNAL_SERVER_ERROR)
+    })
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "id", example = "1", value = "reply(댓글) id")})
+    @ResponseStatus(HttpStatus.OK)
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface DeleteReply {
+    }
+
+    @ApiOperation(value = "콘텐츠 강제 삭제")
+    @ApiResponses({
+            @ApiResponse(code = 400,
+                    message = BAD_REQUEST),
+            @ApiResponse(code = 401,
+                    message = UNAUTHORIZED),
+            @ApiResponse(code = 403,
+                    message = FORBIDDEN),
+            @ApiResponse(code = 500,
+                    message = INTERNAL_SERVER_ERROR)
+    })
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "id", example = "1", value = "board(콘텐츠) id")})
+    @ResponseStatus(HttpStatus.OK)
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface DeleteBoard {
+    }
+
     @ApiOperation(value = "로그인 계정 정보 받아오기")
     @ApiResponses({
             @ApiResponse(code = 400,

--- a/src/main/java/kr/co/moneybridge/core/annotation/SwaggerResponses.java
+++ b/src/main/java/kr/co/moneybridge/core/annotation/SwaggerResponses.java
@@ -57,7 +57,7 @@ public class SwaggerResponses {
     public @interface DefaultApiResponses {
     }
 
-    @ApiOperation(value = "콘텐츠 강제 삭제")
+    @ApiOperation(value = "대댓글 강제 삭제")
     @ApiResponses({
             @ApiResponse(code = 400,
                     message = BAD_REQUEST),

--- a/src/main/java/kr/co/moneybridge/core/util/MyMemberUtil.java
+++ b/src/main/java/kr/co/moneybridge/core/util/MyMemberUtil.java
@@ -49,8 +49,7 @@ public class MyMemberUtil {
     public void deleteById(Long id, Role role) {
         if(role.equals(Role.USER) || role.equals(Role.ADMIN)){
             try{
-                List<Reservation> reservations = reservationRepository.findAllByUserId(id);
-                reservations.stream().forEach(reservation -> {
+                reservationRepository.findAllByUserId(id).stream().forEach(reservation -> {
                     Optional<Review> review = reviewRepository.findByReservationId(reservation.getId());
                     if(review.isPresent()){
                         // review를 지우니, review를 연관관계로 가지고 있는 style삭제
@@ -61,8 +60,7 @@ public class MyMemberUtil {
                 });
                 reservationRepository.deleteByUserId(id);
 
-                List<Reply> replies = replyRepository.findAllByAuthor(id, ReplyAuthorRole.USER);
-                replies.stream().forEach(reply -> {
+                replyRepository.findAllByAuthor(id, ReplyAuthorRole.USER).stream().forEach(reply -> {
                     // reply를 지우니, reply를 연관관계로 가지고 있는 reReply도 삭제
                     reReplyRepository.deleteByReplyId(reply.getId());
                 });
@@ -84,8 +82,7 @@ public class MyMemberUtil {
             deleteFiles(portfolioRepository.findFileByPBId(id), pbRepository.findBusinessCardById(id).get(),
                     pbRepository.findProfileById(id).get(), boardRepository.findThumbnailByPBId(id));
             try{
-                List<Reservation> reservations = reservationRepository.findAllByPBId(id);
-                reservations.stream().forEach(reservation -> {
+                reservationRepository.findAllByPBId(id).stream().forEach(reservation -> {
                     Optional<Review> review = reviewRepository.findByReservationId(reservation.getId());
                     if(review.isPresent()){
                         styleRepository.deleteByReviewId(review.get().getId());
@@ -94,21 +91,18 @@ public class MyMemberUtil {
                 });
                 reservationRepository.deleteByPBId(id);
 
-                List<Reply> replies = replyRepository.findAllByAuthor(id, ReplyAuthorRole.PB);
-                replies.stream().forEach(reply -> {
+                replyRepository.findAllByAuthor(id, ReplyAuthorRole.PB).stream().forEach(reply -> {
                     reReplyRepository.deleteByReplyId(reply.getId());
                 });
                 replyRepository.deleteByAuthor(id, ReplyAuthorRole.PB);
                 reReplyRepository.deleteByAuthor(id, ReplyAuthorRole.PB);
 
-                List<Board> boards = boardRepository.findAllByPBId(id);
-                boards.stream().forEach(board -> {
+                boardRepository.findAllByPBId(id).stream().forEach(board -> {
                     // board를 지우니, board를 연관관계로 가지고 있는 boardBookmark삭제
                     boardBookmarkRepository.deleteByBoardId(board.getId());
-                    List<Reply> repliesOnBoard = replyRepository.findAllByBoardId(board.getId());
-                    repliesOnBoard.stream().forEach(replyOnBoard -> {
+                    replyRepository.findAllByBoardId(board.getId()).stream().forEach(reply -> {
                         // reply를 지우니, reply를 연관관계로 가지고 있는 reReply도 삭제
-                        reReplyRepository.deleteByReplyId(replyOnBoard.getId());
+                        reReplyRepository.deleteByReplyId(reply.getId());
                     });
                     // board를 지우니, board를 연관관계로 가지고 있는 reply삭제
                     replyRepository.deleteByBoardId(board.getId());

--- a/src/main/java/kr/co/moneybridge/model/board/BoardRepository.java
+++ b/src/main/java/kr/co/moneybridge/model/board/BoardRepository.java
@@ -16,6 +16,9 @@ import java.util.List;
 import java.util.Optional;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
+    @Query("select b.thumbnail from Board b where b.id = :boardId")
+    Optional<String> findThumbnailByBoardId(@Param("boardId") Long boardId);
+
     @Query("select b.thumbnail from Board b where b.pb.id = :pbId")
     Optional<String> findThumbnailByPBId(@Param("pbId") Long pbId);
 

--- a/src/main/java/kr/co/moneybridge/service/BackOfficeService.java
+++ b/src/main/java/kr/co/moneybridge/service/BackOfficeService.java
@@ -58,7 +58,7 @@ public class BackOfficeService {
 
     @MyLog
     @Transactional
-    public void deleteRereply(Long id) {
+    public void deleteReReply(Long id) {
         // reReply 삭제
         reReplyRepository.deleteById(id);
     }
@@ -110,9 +110,9 @@ public class BackOfficeService {
                     if(!reviewOP.isEmpty()){
                         reviewTotalDTO =
                                 new BackOfficeResponse.ReviewTotalDTO(reviewOP.get(), styleRepository
-                                        .findAllByReviewId(reviewOP.get().getId()).stream().map(style ->
-                                                new ReservationResponse.StyleDTO(style.getStyle()))
-                                        .collect(Collectors.toList()));}
+                                .findAllByReviewId(reviewOP.get().getId()).stream().map(style ->
+                                        new ReservationResponse.StyleDTO(style.getStyle()))
+                                .collect(Collectors.toList()));}
                     return new BackOfficeResponse.ReservationTotalDTO(reservation,
                             new BackOfficeResponse.UserDTO(reservation.getUser()),
                             new BackOfficeResponse.PBDTO(reservation.getPb()),

--- a/src/main/java/kr/co/moneybridge/service/BackOfficeService.java
+++ b/src/main/java/kr/co/moneybridge/service/BackOfficeService.java
@@ -6,6 +6,7 @@ import kr.co.moneybridge.core.exception.Exception404;
 import kr.co.moneybridge.core.exception.Exception500;
 import kr.co.moneybridge.core.util.MyMemberUtil;
 import kr.co.moneybridge.core.util.MyMsgUtil;
+import kr.co.moneybridge.core.util.S3Util;
 import kr.co.moneybridge.dto.PageDTO;
 import kr.co.moneybridge.dto.backOffice.BackOfficeResponse;
 import kr.co.moneybridge.dto.reservation.ReservationResponse;
@@ -14,6 +15,7 @@ import kr.co.moneybridge.model.backoffice.FrequentQuestion;
 import kr.co.moneybridge.model.backoffice.FrequentQuestionRepository;
 import kr.co.moneybridge.model.backoffice.Notice;
 import kr.co.moneybridge.model.backoffice.NoticeRepository;
+import kr.co.moneybridge.model.board.*;
 import kr.co.moneybridge.model.pb.PB;
 import kr.co.moneybridge.model.pb.PBRepository;
 import kr.co.moneybridge.model.pb.PBStatus;
@@ -48,6 +50,54 @@ public class BackOfficeService {
     private final ReservationRepository reservationRepository;
     private final ReviewRepository reviewRepository;
     private final StyleRepository styleRepository;
+    private final BoardRepository boardRepository;
+    private final BoardBookmarkRepository boardBookmarkRepository;
+    private final ReplyRepository replyRepository;
+    private final ReReplyRepository reReplyRepository;
+    private final S3Util s3Util;
+
+    @MyLog
+    @Transactional
+    public void deleteRereply(Long id) {
+        // reReply 삭제
+        reReplyRepository.deleteById(id);
+    }
+
+    @MyLog
+    @Transactional
+    public void deleteReply(Long id) {
+        // reply를 연관관계로 가지고 있는 reReply도 삭제
+        reReplyRepository.deleteByReplyId(id);
+
+        // reply 삭제
+        replyRepository.deleteById(id);
+    }
+
+    @MyLog
+    @Transactional
+    public void deleteBoard(Long id) {
+        // s3에서 컨텐츠 썸네일도 삭제
+        deleteThumbnail(boardRepository.findThumbnailByBoardId(id));
+
+        // board를 연관관계로 가지고 있는 boardBookmark삭제
+        boardBookmarkRepository.deleteByBoardId(id);
+
+        replyRepository.findAllByBoardId(id).stream().forEach(reply -> {
+            // reply를 지우니, reply를 연관관계로 가지고 있는 reReply도 삭제
+            reReplyRepository.deleteByReplyId(reply.getId());
+        });
+        // board를 연관관계로 가지고 있는 reply삭제
+        replyRepository.deleteByBoardId(id);
+
+        // board 삭제
+        boardRepository.deleteById(id);
+    }
+
+    private void deleteThumbnail(Optional<String> thumbnail){
+        if(thumbnail.isPresent()){
+            s3Util.delete(thumbnail.get());
+        }
+    }
 
     @MyLog
     @Transactional

--- a/src/test/java/kr/co/moneybridge/controller/BackOfficeControllerTest.java
+++ b/src/test/java/kr/co/moneybridge/controller/BackOfficeControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.moneybridge.core.dummy.DummyEntity;
 import kr.co.moneybridge.model.backoffice.FrequentQuestionRepository;
 import kr.co.moneybridge.model.backoffice.NoticeRepository;
+import kr.co.moneybridge.model.board.*;
 import kr.co.moneybridge.model.pb.*;
 import kr.co.moneybridge.model.reservation.*;
 import kr.co.moneybridge.model.user.User;
@@ -63,6 +64,12 @@ public class BackOfficeControllerTest {
     private ReviewRepository reviewRepository;
     @Autowired
     private StyleRepository styleRepository;
+    @Autowired
+    private BoardRepository boardRepository;
+    @Autowired
+    private ReplyRepository replyRepository;
+    @Autowired
+    private ReReplyRepository reReplyRepository;
 
     @BeforeEach
     public void setUp() {
@@ -83,7 +90,72 @@ public class BackOfficeControllerTest {
         Reservation reservation3 = reservationRepository.save(dummy.newCallReservation(user4, pb4, ReservationProcess.COMPLETE));
         Review review = reviewRepository.save(dummy.newReview(reservation1));
         Style style = styleRepository.save(dummy.newStyle(review, StyleStyle.FAST));
+        boardRepository.save(dummy.newBoard("title", pbPS));
+        Board board2 = boardRepository.save(dummy.newBoard("title2", pbPS));
+        replyRepository.save(dummy.newUserReply(board2, user));
+        Reply reply2 = replyRepository.save(dummy.newUserReply(board2, user));
+        reReplyRepository.save(dummy.newPBReReply(reply2, pb2));
         em.clear();
+    }
+
+    @WithUserDetails(value = "ADMIN-admin@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("대댓글 강제 삭제")
+    @Test
+    public void deleteReReply() throws Exception {
+        // given
+        Long id = 1L;
+
+        // when
+        ResultActions resultActions = mvc
+                .perform(delete("/admin/rereply/{id}", id));
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : " + responseBody);
+
+        // then
+        resultActions.andExpect(jsonPath("$.status").value(200));
+        resultActions.andExpect(jsonPath("$.msg").value("ok"));
+        resultActions.andExpect(jsonPath("$.data").isEmpty());
+        resultActions.andExpect(status().isOk());
+    }
+
+    @WithUserDetails(value = "ADMIN-admin@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("댓글 강제 삭제")
+    @Test
+    public void deleteReply() throws Exception {
+        // given
+        Long id = 1L;
+
+        // when
+        ResultActions resultActions = mvc
+                .perform(delete("/admin/reply/{id}", id));
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : " + responseBody);
+
+        // then
+        resultActions.andExpect(jsonPath("$.status").value(200));
+        resultActions.andExpect(jsonPath("$.msg").value("ok"));
+        resultActions.andExpect(jsonPath("$.data").isEmpty());
+        resultActions.andExpect(status().isOk());
+    }
+
+    @WithUserDetails(value = "ADMIN-admin@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("콘텐츠 강제 삭제")
+    @Test
+    public void deleteBoard() throws Exception {
+        // given
+        Long id = 1L;
+
+        // when
+        ResultActions resultActions = mvc
+                .perform(delete("/admin/board/{id}", id));
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : " + responseBody);
+
+        // then
+        resultActions.andExpect(jsonPath("$.status").value(200));
+        resultActions.andExpect(jsonPath("$.msg").value("ok"));
+        resultActions.andExpect(jsonPath("$.data").isEmpty());
+        resultActions.andExpect(status().isOk());
     }
 
     @WithUserDetails(value = "ADMIN-admin@nate.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)

--- a/src/test/java/kr/co/moneybridge/controller/BackOfficeControllerUnitTest.java
+++ b/src/test/java/kr/co/moneybridge/controller/BackOfficeControllerUnitTest.java
@@ -14,6 +14,9 @@ import kr.co.moneybridge.dto.backOffice.BackOfficeResponse;
 import kr.co.moneybridge.dto.reservation.ReservationResponse;
 import kr.co.moneybridge.model.backoffice.FrequentQuestion;
 import kr.co.moneybridge.model.backoffice.Notice;
+import kr.co.moneybridge.model.board.Board;
+import kr.co.moneybridge.model.board.ReReply;
+import kr.co.moneybridge.model.board.Reply;
 import kr.co.moneybridge.model.pb.Branch;
 import kr.co.moneybridge.model.pb.Company;
 import kr.co.moneybridge.model.pb.PB;
@@ -69,6 +72,78 @@ public class BackOfficeControllerUnitTest extends MockDummyEntity {
     private RedisTemplate redisTemplate;
     @MockBean
     private MyMemberUtil myMemberUtil;
+
+    @WithMockAdmin
+    @Test
+    public void deleteRereply_test() throws Exception {
+        // given
+        Long id = 1L;
+        Company company = newMockCompany(1L, "미래에셋증권");
+        Branch branch = newMockBranch(1L, company, 1);
+        PB pb = newMockPB(1L, "pblee", branch);
+        Board board = newMockBoard(1L, "title", pb);
+        Reply reply = newMockPBReply(1L, board, pb);
+        ReReply reReply = newMockPBReReply(1L, reply, pb);
+
+        // stub
+        Mockito.doNothing().when(backOfficeService).deleteReReply(any());
+
+        // When
+        ResultActions resultActions = mvc.perform((delete("/admin/reply/{id}", id)));
+
+        // Then
+        resultActions.andExpect(status().isOk());
+        resultActions.andExpect(jsonPath("$.status").value(200));
+        resultActions.andExpect(jsonPath("$.msg").value("ok"));
+        resultActions.andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @WithMockAdmin
+    @Test
+    public void deleteReply_test() throws Exception {
+        // given
+        Long id = 1L;
+        Company company = newMockCompany(1L, "미래에셋증권");
+        Branch branch = newMockBranch(1L, company, 1);
+        PB pb = newMockPB(1L, "pblee", branch);
+        Board board = newMockBoard(1L, "title", pb);
+        Reply reply = newMockPBReply(1L, board, pb);
+
+        // stub
+        Mockito.doNothing().when(backOfficeService).deleteReply(any());
+
+        // When
+        ResultActions resultActions = mvc.perform((delete("/admin/reply/{id}", id)));
+
+        // Then
+        resultActions.andExpect(status().isOk());
+        resultActions.andExpect(jsonPath("$.status").value(200));
+        resultActions.andExpect(jsonPath("$.msg").value("ok"));
+        resultActions.andExpect(jsonPath("$.data").isEmpty());
+    }
+
+    @WithMockAdmin
+    @Test
+    public void deleteBoard_test() throws Exception {
+        // given
+        Long id = 1L;
+        Company company = newMockCompany(1L, "미래에셋증권");
+        Branch branch = newMockBranch(1L, company, 1);
+        PB pb = newMockPB(1L, "pblee", branch);
+        Board board = newMockBoard(1L, "title", pb);
+
+        // stub
+        Mockito.doNothing().when(backOfficeService).deleteBoard(any());
+
+        // When
+        ResultActions resultActions = mvc.perform((delete("/admin/board/{id}", id)));
+
+        // Then
+        resultActions.andExpect(status().isOk());
+        resultActions.andExpect(jsonPath("$.status").value(200));
+        resultActions.andExpect(jsonPath("$.msg").value("ok"));
+        resultActions.andExpect(jsonPath("$.data").isEmpty());
+    }
 
     @WithMockAdmin
     @Test

--- a/src/test/java/kr/co/moneybridge/model/board/BoardRepositoryTest.java
+++ b/src/test/java/kr/co/moneybridge/model/board/BoardRepositoryTest.java
@@ -65,6 +65,18 @@ public class BoardRepositoryTest extends DummyEntity {
     }
 
     @Test
+    public void findThumbnailByBoardId() {
+        // given
+        Long id = 1L;
+
+        // when
+        Optional<String> thumbnail = boardRepository.findThumbnailByBoardId(id);
+
+        // then
+        assertThat(thumbnail.get()).isEqualTo("thumbnail.png");
+    }
+
+    @Test
     void deleteByPBId() {
         //given
         Long id = 2L;


### PR DESCRIPTION
## Motivation

- 관리자가 강제 게시글(콘텐츠, 댓글, 대댓글) 삭제 API
- 콘텐츠 삭제시 s3에서 썸네일도 삭제

issue #213 