### PR TITLE
Fix: PB 강제 탈퇴 오류 해결

### DIFF
--- a/src/main/java/kr/co/moneybridge/core/util/S3Util.java
+++ b/src/main/java/kr/co/moneybridge/core/util/S3Util.java
@@ -74,15 +74,15 @@ public class S3Util {
     }
 
     // s3에서 파일 삭제
-    public void delete(String profile) {
+    public void delete(String fileName) {
         // 디폴트 폴더에 있는 파일은 삭제 안함
-        if(profile.startsWith(cloudFrontDomain+"/default")) return;
+        if(fileName.startsWith(cloudFrontDomain+"/default")) return;
 
         int index = cloudFrontDomain.length();
-        if(profile.length() < index) return;
-        String fileName = profile.substring(index + 1);
+        if(fileName.length() < index) return;
+        String key = fileName.substring(index + 1);
 
-        s3Client.deleteObject(new DeleteObjectRequest(bucket, fileName));
+        s3Client.deleteObject(new DeleteObjectRequest(bucket, key));
     }
 
     // 이미지 리사이징

--- a/src/main/java/kr/co/moneybridge/model/board/BoardRepository.java
+++ b/src/main/java/kr/co/moneybridge/model/board/BoardRepository.java
@@ -18,7 +18,7 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     Optional<String> findThumbnailByBoardId(@Param("boardId") Long boardId);
 
     @Query("select b.thumbnail from Board b where b.pb.id = :pbId")
-    Optional<String> findThumbnailByPBId(@Param("pbId") Long pbId);
+    List<String> findThumbnailsByPBId(@Param("pbId") Long pbId);
 
     @Query("SELECT new kr.co.moneybridge.dto.user.UserResponse$BookmarkDTO(b) FROM Board b " +
             "JOIN BoardBookmark bb ON bb.board = b WHERE bb.bookmarkerRole = :role AND bb.bookmarkerId = :id")

--- a/src/main/java/kr/co/moneybridge/service/BackOfficeService.java
+++ b/src/main/java/kr/co/moneybridge/service/BackOfficeService.java
@@ -162,7 +162,11 @@ public class BackOfficeService {
     @MyLog
     @Transactional
     public void forceWithdraw(Long memberId, Role role) {
-        myMemberUtil.deleteById(memberId, role);
+        try{
+            myMemberUtil.deleteById(memberId, role);
+        }catch (Exception e){
+
+        }
     }
 
     @MyLog


### PR DESCRIPTION
## Motivation

- PB 강제 탈퇴 오류 해결

문제 원인 : PB ID에 해당하는 썸네일이 여러개인데 쿼리로 조회시 Optional로 바꿔서 오류.
해결 : 쿼리에서 List로 받음 

문제 상황 : 오류 날릴 떄 throw를 안써서 rollback이 안됐음
해결 : throw를 써줌

close #160 