### PR TITLE
Fix: 로그인시 쿠키 설정 불린 추가

### DIFF
--- a/src/main/java/kr/co/moneybridge/controller/UserController.java
+++ b/src/main/java/kr/co/moneybridge/controller/UserController.java
@@ -180,8 +180,13 @@ public class UserController {
 
         Pair<String, String> tokens = userService.issue(loginInDTO.getRole(), loginInDTO.getEmail(), loginInDTO.getPassword());
         // HttpOnly 플래그 설정 (XSS 방지 - 자바스크립트로 쿠키 접근 불가),
-        response.setHeader("Set-Cookie", "refreshToken=" + tokens.getRight()
-                + "; Max-Age="+MyJwtProvider.EXP_REFRESH+"; SameSite=None; Secure; HttpOnly; Path=/");
+        if(loginInDTO.getRemember()){ // 브라우저 종료 후에도 로그인 상태 유지하려면
+            response.setHeader("Set-Cookie", "refreshToken=" + tokens.getRight()
+                    + "; Max-Age="+MyJwtProvider.EXP_REFRESH+"; SameSite=None; Secure; HttpOnly; Path=/");
+        } else {
+            response.setHeader("Set-Cookie", "refreshToken=" + tokens.getRight()
+                    + "; SameSite=None; Secure; HttpOnly; Path=/");
+        }
         return ResponseEntity.ok()
                 .header(MyJwtProvider.HEADER_ACCESS, tokens.getLeft())
                 .body(responseDTO);

--- a/src/main/java/kr/co/moneybridge/dto/user/UserRequest.java
+++ b/src/main/java/kr/co/moneybridge/dto/user/UserRequest.java
@@ -225,5 +225,9 @@ public class UserRequest {
         @NotEmpty
         @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=\\S+$).{8,}$", message = "공백없이 영문(대소문자), 숫자 포함해서 8자 이상으로 작성해주세요")
         private String password;
+
+        @ApiModelProperty(example = "true", value = "true면 영속쿠키, false면 세션쿠키")
+        @NotNull
+        private Boolean remember;
     }
 }

--- a/src/test/java/kr/co/moneybridge/controller/UserControllerTest.java
+++ b/src/test/java/kr/co/moneybridge/controller/UserControllerTest.java
@@ -407,6 +407,7 @@ public class UserControllerTest {
         loginInDTO.setRole(Role.USER);
         loginInDTO.setEmail("로그인@nate.com");
         loginInDTO.setPassword("password1234");
+        loginInDTO.setRemember(true);
         String requestBody = om.writeValueAsString(loginInDTO);
 
         // when
@@ -431,6 +432,7 @@ public class UserControllerTest {
         loginInDTO.setRole(Role.PB);
         loginInDTO.setEmail("김피비@nate.com");
         loginInDTO.setPassword("password1234");
+        loginInDTO.setRemember(true);
         String requestBody = om.writeValueAsString(loginInDTO);
 
         // when
@@ -455,6 +457,7 @@ public class UserControllerTest {
         loginInDTO.setRole(Role.USER);
         loginInDTO.setEmail("jisu3148496@naver.com");
         loginInDTO.setPassword("password1234");
+        loginInDTO.setRemember(true);
         String requestBody = om.writeValueAsString(loginInDTO);
 
         // when
@@ -480,6 +483,7 @@ public class UserControllerTest {
         loginInDTO.setRole(Role.USER);
         loginInDTO.setEmail("로그인@nate.com");
         loginInDTO.setPassword("password1234");
+        loginInDTO.setRemember(true);
         String loginRequestBody = om.writeValueAsString(loginInDTO);
 
         MvcResult loginResult = mvc
@@ -515,6 +519,7 @@ public class UserControllerTest {
         loginInDTO.setRole(Role.USER);
         loginInDTO.setEmail("로그인@nate.com");
         loginInDTO.setPassword("password1234");
+        loginInDTO.setRemember(true);
         String loginRequestBody = om.writeValueAsString(loginInDTO);
 
         MvcResult loginResult = mvc

--- a/src/test/java/kr/co/moneybridge/controller/UserControllerUnitTest.java
+++ b/src/test/java/kr/co/moneybridge/controller/UserControllerUnitTest.java
@@ -429,6 +429,7 @@ public class UserControllerUnitTest extends MockDummyEntity {
         loginInDTO.setRole(Role.USER);
         loginInDTO.setEmail("로그인@nate.com");
         loginInDTO.setPassword("password1234");
+        loginInDTO.setRemember(true);
         String requestBody = om.writeValueAsString(loginInDTO);
 
         // stub
@@ -462,6 +463,7 @@ public class UserControllerUnitTest extends MockDummyEntity {
         loginInDTO.setRole(Role.USER);
         loginInDTO.setEmail("로그인@nate.com");
         loginInDTO.setPassword("password1234");
+        loginInDTO.setRemember(true);
         String requestBody = om.writeValueAsString(loginInDTO);
 
         // stub

--- a/src/test/java/kr/co/moneybridge/model/board/BoardRepositoryTest.java
+++ b/src/test/java/kr/co/moneybridge/model/board/BoardRepositoryTest.java
@@ -107,10 +107,10 @@ public class BoardRepositoryTest extends DummyEntity {
         Long id = 1L;
 
         // when
-        Optional<String> thumbnail = boardRepository.findThumbnailByPBId(id);
+        List<String> thumbnail = boardRepository.findThumbnailsByPBId(id);
 
         // then
-        assertThat(thumbnail.get()).isEqualTo("thumbnail.png");
+        assertThat(thumbnail.get(0)).isEqualTo("thumbnail.png");
     }
 
     @Test


### PR DESCRIPTION
## Motivation

- 로그인시 쿠키 설정 불린 추가
- remember가 true면 Max-Age를 설정해서 브라우조 종료 후에도 쿠키가 유지되도록 하고, remember가 false면 그냥 세션에만 저장해서 브라우저 종료 후에는 쿠키가 사라지도록 함. 이렇게 한 이유는 로그아웃시에도 쿠키로 리프레시토큰을 전달해주어야 하기 때문에

issue #22 