### PR TITLE
Fix: s3 버킷명, 이메일 헤더 변경

### DIFF
--- a/src/main/java/kr/co/moneybridge/core/util/MyMsgUtil.java
+++ b/src/main/java/kr/co/moneybridge/core/util/MyMsgUtil.java
@@ -14,7 +14,7 @@ import javax.mail.internet.MimeMessage;
 @Component
 public class MyMsgUtil {
     private final JavaMailSender javaMailSender;
-    private final String header = "<img src=\"https://d2ky5wm6akosox.cloudfront.net/default/email_header.png\" />\n";
+    private final String header = "<img src=\"https://moneybridge.s3.ap-northeast-2.amazonaws.com/default/email_header.png\" />\n";
     @Getter
     public final String subjectReject = "[Money Bridge] 회원가입 승인 거절 안내드립니다.";
     @Getter

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -39,7 +39,7 @@ cloud:
       accessKey: ${S3_ACCESS_KEY}
       secretKey: ${S3_SECRET_KEY}
     s3:
-      bucket: money-bridge
+      bucket: moneybridge
     region:
       static: ap-northeast-2
     stack:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -40,7 +40,7 @@ cloud:
       accessKey: ${S3_ACCESS_KEY}
       secretKey: ${S3_SECRET_KEY}
     s3:
-      bucket: money-bridge
+      bucket: moneybridge
     region:
       static: ap-northeast-2
     stack:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -34,7 +34,7 @@ cloud:
       accessKey: ${S3_ACCESS_KEY}
       secretKey: ${S3_SECRET_KEY}
     s3:
-      bucket: money-bridge
+      bucket: moneybridge
     region:
       static: ap-northeast-2
     stack:


### PR DESCRIPTION
## Motivation

- s3 버킷명 money-bridge에서 moneybridge로 변경
- 이메일 헤더 이미지도 s3 버킷의 default 폴더에 넣고 링크 주소 cloudfront에서 s3로 변경
