### PR TITLE
Fix: 유지보수 1-4

### DIFF
--- a/src/main/java/kr/co/moneybridge/controller/BackOfficeController.java
+++ b/src/main/java/kr/co/moneybridge/controller/BackOfficeController.java
@@ -1,5 +1,6 @@
 package kr.co.moneybridge.controller;
 
+import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiOperation;
 import kr.co.moneybridge.core.annotation.MyLog;
 import kr.co.moneybridge.core.annotation.SwaggerResponses;
@@ -156,15 +157,24 @@ public class BackOfficeController {
         return new ResponseDTO<>(countDTO);
     }
 
-    // 회원 리스트 가져오기
+    // 투자자 리스트 가져오기
     @MyLog
-    @SwaggerResponses.GetMembers
-    @GetMapping("/admin/members")
-    public ResponseDTO<PageDTO<BackOfficeResponse.MemberOutDTO>> getMembers(@RequestParam(defaultValue = "user") String type,
-                                                                   @RequestParam(defaultValue = "0") int page) {
-        if(!type.equals("user") && !type.equals("pb")) throw new Exception400("type", "user과 pb만 가능합니다");
-        Pageable pbPageable = PageRequest.of(page, 10, Sort.by(Sort.Direction.DESC, "id"));
-        PageDTO<BackOfficeResponse.MemberOutDTO> pageDTO = backOfficeService.getMembers(type, pbPageable);
+    @SwaggerResponses.GetUsers
+    @ApiImplicitParam(name = "page", example = "0", value = "현재 페이지 번호")
+    @GetMapping("/admin/users")
+    public ResponseDTO<PageDTO<BackOfficeResponse.UserOutDTO>> getUsers(@RequestParam(defaultValue = "0") int page) {
+        Pageable pageable = PageRequest.of(page, 10, Sort.by(Sort.Direction.DESC, "id"));
+        PageDTO<BackOfficeResponse.UserOutDTO> pageDTO = backOfficeService.getUsers(pageable);
+        return new ResponseDTO<>(pageDTO);
+    }
+
+    @MyLog
+    @SwaggerResponses.GetPBs
+    @ApiImplicitParam(name = "page", example = "0", value = "현재 페이지 번호")
+    @GetMapping("/admin/pbs")
+    public ResponseDTO<PageDTO<BackOfficeResponse.PBOutDTO>> getPBs(@RequestParam(defaultValue = "0") int page) {
+        Pageable pageable = PageRequest.of(page, 10, Sort.by(Sort.Direction.DESC, "id"));
+        PageDTO<BackOfficeResponse.PBOutDTO> pageDTO = backOfficeService.getPBs(pageable);
         return new ResponseDTO<>(pageDTO);
     }
 
@@ -180,7 +190,7 @@ public class BackOfficeController {
     // PB 회원 가입 승인 대기 리스트 가져오기
     @MyLog
     @SwaggerResponses.GetPBPending
-    @GetMapping("/admin/pbs")
+    @GetMapping("/admin/pendings")
     public ResponseDTO<PageDTO<BackOfficeResponse.PBPendingDTO>> getPBPending(@RequestParam(defaultValue = "0") int page) {
         Pageable pageable = PageRequest.of(page, 10, Sort.by(Sort.Direction.DESC, "id"));
         PageDTO<BackOfficeResponse.PBPendingDTO> pageDTO = backOfficeService.getPBPending(pageable);

--- a/src/main/java/kr/co/moneybridge/core/annotation/SwaggerResponses.java
+++ b/src/main/java/kr/co/moneybridge/core/annotation/SwaggerResponses.java
@@ -853,4 +853,20 @@ public class SwaggerResponses {
     @Retention(RetentionPolicy.RUNTIME)
     public @interface ApiResponsesWithout400 {
     }
+
+    @ApiOperation(value = "휴대폰 번호 중복 체크")
+    @ApiResponses({
+            @ApiResponse(code = 400,
+                    message = BAD_REQUEST),
+            @ApiResponse(code = 404,
+                    message = NOT_FOUND),
+            @ApiResponse(code = 500,
+                    message = INTERNAL_SERVER_ERROR)
+    })
+    @ApiImplicitParams({@ApiImplicitParam(name = "type", example = "user", value = "투자자는 user, PB는 pb")})
+    @ResponseStatus(HttpStatus.OK)
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface PhoneNumber {
+    }
 }

--- a/src/main/java/kr/co/moneybridge/core/annotation/SwaggerResponses.java
+++ b/src/main/java/kr/co/moneybridge/core/annotation/SwaggerResponses.java
@@ -311,7 +311,7 @@ public class SwaggerResponses {
     public @interface GetMembersCount {
     }
 
-    @ApiOperation(value = "회원 리스트 가져오기")
+    @ApiOperation(value = "투자자 리스트 가져오기")
     @ApiResponses({
             @ApiResponse(code = 400,
                     message = BAD_REQUEST),
@@ -322,13 +322,27 @@ public class SwaggerResponses {
             @ApiResponse(code = 500,
                     message = INTERNAL_SERVER_ERROR)
     })
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "type", example = "user", value = "user(디폴트) 또는 pb"),
-            @ApiImplicitParam(name = "page", example = "0", value = "현재 페이지 번호")})
     @ResponseStatus(HttpStatus.OK)
     @Target(ElementType.METHOD)
     @Retention(RetentionPolicy.RUNTIME)
-    public @interface GetMembers {
+    public @interface GetUsers {
+    }
+
+    @ApiOperation(value = "PB 리스트 가져오기")
+    @ApiResponses({
+            @ApiResponse(code = 400,
+                    message = BAD_REQUEST),
+            @ApiResponse(code = 401,
+                    message = UNAUTHORIZED),
+            @ApiResponse(code = 403,
+                    message = FORBIDDEN),
+            @ApiResponse(code = 500,
+                    message = INTERNAL_SERVER_ERROR)
+    })
+    @ResponseStatus(HttpStatus.OK)
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface GetPBs {
     }
 
     @ApiOperation(value = "해당 PB 승인/승인 거부")

--- a/src/main/java/kr/co/moneybridge/core/util/MyMemberUtil.java
+++ b/src/main/java/kr/co/moneybridge/core/util/MyMemberUtil.java
@@ -134,16 +134,16 @@ public class MyMemberUtil {
         thumbnails.stream().forEach(thumbnail -> s3Util.delete(thumbnail));
     }
 
-    public List<Member> findByNameAndPhoneNumberWithoutException(String name, String phoneNumber, Role role) {
+    public List<Member> findByPhoneNumberWithoutException(String phoneNumber, Role role) {
         List<Member> members = null;
         if(role.equals(Role.USER) || role.equals(Role.ADMIN)){
-            List<User> users = userRepository.findByNameAndPhoneNumber(name, phoneNumber);
+            List<User> users = userRepository.findByPhoneNumber(phoneNumber);
             if(users.isEmpty()){
                 return null;
             }
             members = new ArrayList<>(users);
         } else if(role.equals(Role.PB)) {
-            List<PB> pbs = pbRepository.findByNameAndPhoneNumber(name, phoneNumber);
+            List<PB> pbs = pbRepository.findByPhoneNumber(phoneNumber);
             if (pbs.isEmpty()) {
                 return null;
             }

--- a/src/main/java/kr/co/moneybridge/dto/backOffice/BackOfficeResponse.java
+++ b/src/main/java/kr/co/moneybridge/dto/backOffice/BackOfficeResponse.java
@@ -2,12 +2,12 @@ package kr.co.moneybridge.dto.backOffice;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import kr.co.moneybridge.core.util.MyDateUtil;
 import kr.co.moneybridge.dto.reservation.ReservationResponse;
 import kr.co.moneybridge.model.Member;
 import kr.co.moneybridge.model.Role;
 import kr.co.moneybridge.model.backoffice.FrequentQuestion;
 import kr.co.moneybridge.model.backoffice.Notice;
+import kr.co.moneybridge.model.pb.Branch;
 import kr.co.moneybridge.model.pb.PB;
 import kr.co.moneybridge.model.pb.PBSpeciality;
 import kr.co.moneybridge.model.reservation.*;
@@ -16,7 +16,6 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
@@ -199,10 +198,10 @@ public class BackOfficeResponse {
         }
     }
 
-    @ApiModel(description = "회원 관리 페이지 전체 가져오기 응답 데이터")
+    @ApiModel(description = "회원 관리 페이지 투자자 전체 가져오기 응답 데이터")
     @Getter
     @Setter
-    public static class MemberOutDTO {
+    public static class UserOutDTO {
         @ApiModelProperty(example = "1", value = "투자자 id")
         private Long id;
 
@@ -218,16 +217,52 @@ public class BackOfficeResponse {
         @ApiModelProperty(example = "01012345678", value = "휴대폰 번호")
         private String phoneNumber;
 
-        @ApiModelProperty(example = "true", value = "관리자 여부(관리자면 true, 아니면 false(PB는 항상 false))")
+        @ApiModelProperty(example = "true", value = "관리자 여부(관리자면 true, 아니면 false)")
         private Boolean isAdmin;
 
-        public MemberOutDTO(Member member) {
+        public UserOutDTO(Member member) {
             this.id = member.getId();
             this.createdAt = localDateTimeToString(member.getCreatedAt());
             this.email = member.getEmail();
             this.name = member.getName();
             this.phoneNumber = member.getPhoneNumber();
             this.isAdmin = member.getRole() == Role.ADMIN ? true : false;
+        }
+    }
+
+    @ApiModel(description = "회원 관리 페이지 PB 전체 가져오기 응답 데이터")
+    @Getter
+    @Setter
+    public static class PBOutDTO {
+        @ApiModelProperty(example = "1", value = "투자자 id")
+        private Long id;
+
+        @ApiModelProperty(example = "2023-01-01", value = "가입일")
+        private String createdAt;
+
+        @ApiModelProperty(example = "김PB@nate.com", value = "이메일")
+        private String email;
+
+        @ApiModelProperty(example = "김PB", value = "이름")
+        private String name;
+
+        @ApiModelProperty(example = "01012345678", value = "휴대폰 번호")
+        private String phoneNumber;
+
+        @ApiModelProperty(example = "true", value = "관리자 여부(관리자면 true, 아니면 false)")
+        private String businessCard;
+
+        @ApiModelProperty(example = "KB증권 용산점", value = "증권사 지점명")
+        private String branchName;
+
+        public PBOutDTO(PB pb, Branch branch) {
+            this.id = pb.getId();
+            this.createdAt = localDateTimeToString(pb.getCreatedAt());
+            this.email = pb.getEmail();
+            this.name = pb.getName();
+            this.phoneNumber = pb.getPhoneNumber();
+            this.businessCard = pb.getBusinessCard();
+            this.branchName = branch.getName();
         }
     }
 

--- a/src/main/java/kr/co/moneybridge/dto/backOffice/BackOfficeResponse.java
+++ b/src/main/java/kr/co/moneybridge/dto/backOffice/BackOfficeResponse.java
@@ -279,7 +279,7 @@ public class BackOfficeResponse {
         @ApiModelProperty(example = "윤pb", value = "이름")
         private String name;
 
-        @ApiModelProperty(example = "01012345678", value = "핸드폰 번호")
+        @ApiModelProperty(example = "01012345678", value = "휴대폰 번호")
         private String phoneNumber;
 
         @ApiModelProperty(example = "미래에셋증권 여의도점", value = "지점명")

--- a/src/main/java/kr/co/moneybridge/dto/user/UserRequest.java
+++ b/src/main/java/kr/co/moneybridge/dto/user/UserRequest.java
@@ -93,10 +93,6 @@ public class UserRequest {
         @NotNull
         private Role role;
 
-        @ApiModelProperty(example = "사용자")
-        @NotEmpty
-        private String name;
-
         @ApiModelProperty(example = "jisu8496@naver.com")
         @NotEmpty
         @Email(message = "이메일 형식으로 작성해주세요")

--- a/src/main/java/kr/co/moneybridge/dto/user/UserRequest.java
+++ b/src/main/java/kr/co/moneybridge/dto/user/UserRequest.java
@@ -74,10 +74,6 @@ public class UserRequest {
         @NotNull
         private Role role;
 
-        @ApiModelProperty(example = "김투자")
-        @NotEmpty
-        private String name;
-
         @ApiModelProperty(example = "01012345678")
         @NotEmpty
         @Pattern(regexp = "^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$",

--- a/src/main/java/kr/co/moneybridge/dto/user/UserRequest.java
+++ b/src/main/java/kr/co/moneybridge/dto/user/UserRequest.java
@@ -109,6 +109,17 @@ public class UserRequest {
         private String email;
     }
 
+    @ApiModel(description = "휴대폰 번호 중복 체크 요청 데이터")
+    @Setter
+    @Getter
+    public static class PhoneNumberInDTO {
+        @ApiModelProperty(example = "01012345678")
+        @NotEmpty
+        @Pattern(regexp = "^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$",
+                message = "유효하지 않은 휴대폰 번호 형식입니다.")
+        private String phoneNumber;
+    }
+
     @ApiModel(description = "탈퇴시 요청 데이터")
     @Setter
     @Getter

--- a/src/main/java/kr/co/moneybridge/dto/user/UserResponse.java
+++ b/src/main/java/kr/co/moneybridge/dto/user/UserResponse.java
@@ -231,6 +231,18 @@ public class UserResponse {
         }
     }
 
+    @ApiModel(description = "휴대폰 번호 중복 체크 응답 데이터")
+    @Setter
+    @Getter
+    public static class PhoneNumberOutDTO {
+        @ApiModelProperty(example = "true", value = "중복 여부(true or false)")
+        private boolean isDuplicated;
+
+        public PhoneNumberOutDTO(boolean isDuplicated) {
+            this.isDuplicated = isDuplicated;
+        }
+    }
+
     @ApiModel(description = "투자자 회원 가입시 응답 데이터")
     @Setter
     @Getter

--- a/src/main/java/kr/co/moneybridge/model/pb/PBRepository.java
+++ b/src/main/java/kr/co/moneybridge/model/pb/PBRepository.java
@@ -1,5 +1,6 @@
 package kr.co.moneybridge.model.pb;
 
+import kr.co.moneybridge.dto.backOffice.BackOfficeResponse;
 import kr.co.moneybridge.dto.pb.PBResponse;
 import kr.co.moneybridge.dto.user.UserResponse;
 import kr.co.moneybridge.model.reservation.ReservationProcess;
@@ -24,6 +25,11 @@ public interface PBRepository extends JpaRepository<PB, Long> {
 
     @Query("select p from PB p where p.status = :status")
     Page<PB> findAllByStatus(@Param("status") PBStatus status, Pageable pageable);
+
+    @Query("select new kr.co.moneybridge.dto.backOffice.BackOfficeResponse$PBOutDTO(p, br) from PB p " +
+            "join Branch br " +
+            "where p.status = :status")
+    Page<BackOfficeResponse.PBOutDTO> findPagesByStatus(@Param("status") PBStatus status, Pageable pageable);
 
     @Query("select p from PB p where p.id in :list")
     List<PB> findByIdIn(@Param("list") List<Long> list);

--- a/src/main/java/kr/co/moneybridge/model/pb/PBRepository.java
+++ b/src/main/java/kr/co/moneybridge/model/pb/PBRepository.java
@@ -56,8 +56,8 @@ public interface PBRepository extends JpaRepository<PB, Long> {
     @Query("SELECT COUNT(rv) FROM Review rv JOIN Reservation r ON rv.reservation = r WHERE r.pb.id = :pbId")
     Long countReviewsByPbId(@Param("pbId") Long pbId);
 
-    @Query("select p from PB p where p.name = :name and p.phoneNumber = :phoneNumber")
-    List<PB> findByNameAndPhoneNumber(@Param("name") String name, @Param("phoneNumber") String phoneNumber);
+    @Query("select p from PB p where p.phoneNumber = :phoneNumber")
+    List<PB> findByPhoneNumber(@Param("phoneNumber") String phoneNumber);
 
     @Query("SELECT new kr.co.moneybridge.dto.pb.PBResponse$PBPageDTO(pb, b, c) FROM PB pb " +
             "JOIN Branch b ON pb.branch = b " +

--- a/src/main/java/kr/co/moneybridge/model/pb/PBRepository.java
+++ b/src/main/java/kr/co/moneybridge/model/pb/PBRepository.java
@@ -152,5 +152,6 @@ public interface PBRepository extends JpaRepository<PB, Long> {
             "ORDER BY pb.id DESC")
     List<PBResponse.PBPageDTO> findBySpeciality1(@Param("speciality1")PBSpeciality speciality1, Pageable pageable);
 
-
+    @Query("select count(*) from PB p where p.phoneNumber = :phoneNumber")
+    int countByPhoneNumber(@Param("phoneNumber") String phoneNumber);
 }

--- a/src/main/java/kr/co/moneybridge/model/user/UserRepository.java
+++ b/src/main/java/kr/co/moneybridge/model/user/UserRepository.java
@@ -21,4 +21,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
             "join Review rev on rev.reservation.id = res.id " +
             "where rev.id = :reviewId")
     User findUserByReviewId(@Param("reviewId") Long reviewId);
+
+    @Query("select count(*) from User u where u.phoneNumber = :phoneNumber")
+    int countByPhoneNumber(@Param("phoneNumber") String phoneNumber);
 }

--- a/src/main/java/kr/co/moneybridge/model/user/UserRepository.java
+++ b/src/main/java/kr/co/moneybridge/model/user/UserRepository.java
@@ -12,8 +12,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(@Param("email") String email);
 
 
-    @Query("select u from User u where u.name = :name and u.phoneNumber = :phoneNumber")
-    List<User> findByNameAndPhoneNumber(@Param("name") String name, @Param("phoneNumber") String phoneNumber);
+    @Query("select u from User u where u.phoneNumber = :phoneNumber")
+    List<User> findByPhoneNumber(@Param("phoneNumber") String phoneNumber);
 
     @Query("select u " +
             "from User u " +

--- a/src/main/java/kr/co/moneybridge/service/BackOfficeService.java
+++ b/src/main/java/kr/co/moneybridge/service/BackOfficeService.java
@@ -248,18 +248,24 @@ public class BackOfficeService {
     }
 
     @MyLog
-    public PageDTO<BackOfficeResponse.MemberOutDTO> getMembers(String type, Pageable pageable) {
-        if (type.equals("user")) {
-            Page<User> userPG = userRepository.findAll(pageable);
-            List<BackOfficeResponse.MemberOutDTO> list = userPG.getContent().stream().map(user ->
-                    new BackOfficeResponse.MemberOutDTO(user)).collect(Collectors.toList());
-            return new PageDTO<>(list, userPG, User.class);
-        }
+    public PageDTO<BackOfficeResponse.UserOutDTO> getUsers(Pageable pageable) {
+        Page<User> userPG = userRepository.findAll(pageable);
+        List<BackOfficeResponse.UserOutDTO> list =
+                userPG.getContent()
+                        .stream()
+                        .map(user -> new BackOfficeResponse.UserOutDTO(user))
+                        .collect(Collectors.toList());
+        return new PageDTO<>(list, userPG, User.class);
+    }
 
-        Page<PB> pbPG = pbRepository.findAllByStatus(PBStatus.ACTIVE, pageable);
-        List<BackOfficeResponse.MemberOutDTO> list = pbPG.getContent().stream().map(pb ->
-                new BackOfficeResponse.MemberOutDTO(pb)).collect(Collectors.toList());
-        return new PageDTO<>(list, pbPG, PB.class);
+    @MyLog
+    public PageDTO<BackOfficeResponse.PBOutDTO> getPBs(Pageable pageable) {
+        Page<BackOfficeResponse.PBOutDTO> pbOutPG = pbRepository.findPagesByStatus(PBStatus.ACTIVE, pageable);
+        List<BackOfficeResponse.PBOutDTO> list =
+                pbOutPG.getContent()
+                        .stream()
+                        .collect(Collectors.toList());
+        return new PageDTO<>(list, pbOutPG);
     }
 
     @MyLog

--- a/src/main/java/kr/co/moneybridge/service/UserService.java
+++ b/src/main/java/kr/co/moneybridge/service/UserService.java
@@ -178,6 +178,23 @@ public class UserService {
         return emailOutDTO;
     }
 
+    @MyLog
+    public UserResponse.PhoneNumberOutDTO checkPhoneNumber(String type, String phoneNumber) {
+        if (type.equals("user")) {
+            int count = userRepository.countByPhoneNumber(phoneNumber);
+            if (count >= 1) {
+                return new UserResponse.PhoneNumberOutDTO(true);
+            }
+            return new UserResponse.PhoneNumberOutDTO(false);
+        }
+
+        int count = pbRepository.countByPhoneNumber(phoneNumber);
+        if (count >= 1) {
+            return new UserResponse.PhoneNumberOutDTO(true);
+        }
+        return new UserResponse.PhoneNumberOutDTO(false);
+    }
+
     private String sendEmail(String email) {
         String code = createCode();
         MimeMessage message = myMsgUtil.createMessage(email, myMsgUtil.getSubjectAuthenticate(),

--- a/src/main/java/kr/co/moneybridge/service/UserService.java
+++ b/src/main/java/kr/co/moneybridge/service/UserService.java
@@ -29,7 +29,6 @@ import kr.co.moneybridge.model.reservation.ReservationRepository;
 import kr.co.moneybridge.model.user.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -41,7 +40,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 import javax.servlet.http.HttpServletRequest;
 import java.util.*;
@@ -107,10 +105,10 @@ public class UserService {
         Role role = myUserDetails.getMember().getRole();
         Member memberPS = myMemberUtil.findById(id, role);
 
-        if(updateMyInfoInDTO.getName() != null && !updateMyInfoInDTO.getName().isEmpty()) { // isEmpty()는 null이 아닐 때만 확인 가능
+        if (updateMyInfoInDTO.getName() != null && !updateMyInfoInDTO.getName().isEmpty()) { // isEmpty()는 null이 아닐 때만 확인 가능
             memberPS.updateName(updateMyInfoInDTO.getName());
         }
-        if (updateMyInfoInDTO.getPhoneNumber() != null && !updateMyInfoInDTO.getPhoneNumber().isEmpty()){
+        if (updateMyInfoInDTO.getPhoneNumber() != null && !updateMyInfoInDTO.getPhoneNumber().isEmpty()) {
             memberPS.updatePhoneNumber(updateMyInfoInDTO.getPhoneNumber());
         }
     }
@@ -122,7 +120,7 @@ public class UserService {
 
     @MyLog
     public void checkPassword(UserRequest.CheckPasswordInDTO checkPasswordInDTO, MyUserDetails myUserDetails) {
-        if(!passwordEncoder.matches(checkPasswordInDTO.getPassword(), myUserDetails.getPassword())){
+        if (!passwordEncoder.matches(checkPasswordInDTO.getPassword(), myUserDetails.getPassword())) {
             throw new Exception401("비밀번호가 틀렸습니다");
         }
     }
@@ -137,9 +135,11 @@ public class UserService {
 
     @MyLog
     public List<UserResponse.EmailFindOutDTO> findEmail(UserRequest.EmailFindInDTO emailFindInDTO) {
-        List<Member> membersPS = myMemberUtil.findByNameAndPhoneNumberWithoutException(emailFindInDTO.getName(),
-            emailFindInDTO.getPhoneNumber(), emailFindInDTO.getRole());
-        if(membersPS == null){
+        List<Member> membersPS = myMemberUtil.findByPhoneNumberWithoutException(
+                emailFindInDTO.getPhoneNumber(),
+                emailFindInDTO.getRole()
+        );
+        if (membersPS == null) {
             return Arrays.asList(new UserResponse.EmailFindOutDTO());
         }
         List<UserResponse.EmailFindOutDTO> emailFindOutDTOs = new ArrayList<>();
@@ -150,7 +150,7 @@ public class UserService {
     @MyLog
     public UserResponse.PasswordOutDTO password(UserRequest.PasswordInDTO passwordInDTO) throws Exception {
         Member memberPS = myMemberUtil.findByEmailWithoutException(passwordInDTO.getEmail(), passwordInDTO.getRole());
-        if(memberPS == null){
+        if (memberPS == null) {
             return new UserResponse.PasswordOutDTO();
         }
         String code = sendEmail(passwordInDTO.getEmail());
@@ -161,15 +161,15 @@ public class UserService {
     @MyLog
     public UserResponse.EmailOutDTO email(UserRequest.EmailInDTO emailInDTO) {
         Member memberPS = myMemberUtil.findByEmailWithoutException(emailInDTO.getEmail(), emailInDTO.getRole());
-        if(memberPS != null){
-            if(emailInDTO.getRole().equals(Role.USER)){
+        if (memberPS != null) {
+            if (emailInDTO.getRole().equals(Role.USER)) {
                 throw new Exception400("email", "이미 투자자로 회원가입된 이메일입니다");
             }
-            PB pb = (PB)memberPS;
-            if(pb.getStatus().equals(PBStatus.PENDING)){
+            PB pb = (PB) memberPS;
+            if (pb.getStatus().equals(PBStatus.PENDING)) {
                 throw new Exception400("email", "회원가입 후 승인을 기다리고 있는 PB 계정입니다");
             }
-            if(pb.getStatus().equals(PBStatus.ACTIVE)){
+            if (pb.getStatus().equals(PBStatus.ACTIVE)) {
                 throw new Exception400("email", "이미 PB로 회원가입된 이메일입니다");
             }
         }
@@ -202,7 +202,7 @@ public class UserService {
     @MyLog
     @Transactional
     public void withdraw(UserRequest.WithdrawInDTO withdrawInDTO, MyUserDetails myUserDetails) {
-        if(!passwordEncoder.matches(withdrawInDTO.getPassword(), myUserDetails.getPassword())){
+        if (!passwordEncoder.matches(withdrawInDTO.getPassword(), myUserDetails.getPassword())) {
             throw new Exception401("비밀번호가 틀렸습니다");
         }
         myMemberUtil.deleteById(myUserDetails.getMember().getId(), myUserDetails.getMember().getRole());
@@ -210,10 +210,10 @@ public class UserService {
 
     @MyLog
     @Transactional
-    public UserResponse.JoinOutDTO joinUser(UserRequest.JoinInDTO joinInDTO){
+    public UserResponse.JoinOutDTO joinUser(UserRequest.JoinInDTO joinInDTO) {
 
         Optional<User> userOP = userRepository.findByEmail(joinInDTO.getEmail());
-        if(userOP.isPresent()){
+        if (userOP.isPresent()) {
             throw new Exception400("email", "이미 투자자로 회원가입된 이메일입니다");
         }
         String encPassword = passwordEncoder.encode(joinInDTO.getPassword()); // 60Byte
@@ -222,12 +222,12 @@ public class UserService {
         try {
             User userPS = userRepository.save(joinInDTO.toEntity(defaultProfile));
             List<UserRequest.AgreementDTO> agreements = joinInDTO.getAgreements();
-            if(agreements != null){
+            if (agreements != null) {
                 agreements.stream().forEach(agreement ->
                         userAgreementRepository.save(agreement.toEntity(userPS)));
             }
             return new UserResponse.JoinOutDTO(userPS);
-        }catch (Exception e){
+        } catch (Exception e) {
             throw new Exception500("회원가입 실패 : " + e.getMessage());
         }
     }
@@ -246,7 +246,7 @@ public class UserService {
             String accessToken = myJwtProvider.createAccess(myUserDetails.getMember());
             String refreshToken = myJwtProvider.createRefresh(myUserDetails.getMember());
             return Pair.of(accessToken, refreshToken);
-        }catch (Exception e){
+        } catch (Exception e) {
             throw new Exception500("토큰 발급 실패: " + e.getMessage());
         }
     }
@@ -256,7 +256,7 @@ public class UserService {
         User userPS = userRepository.findByEmail(loginInDTO.getEmail()).orElseThrow(
                 () -> new Exception404("해당하는 계정이 없습니다")
         );
-        if(!userPS.getRole().equals(Role.ADMIN)){
+        if (!userPS.getRole().equals(Role.ADMIN)) {
             throw new Exception400("email", "관리자 계정이 아닙니다");
         }
         String code = sendEmail(loginInDTO.getEmail());
@@ -294,7 +294,7 @@ public class UserService {
             throw new Exception500("토큰을 재발급할 수 없습니다. 다시 로그인 해주세요");
         }
         // 6) Redis에 저장된 refresh token이 사용자가 요청한 refresh token과 같아야 함.
-        if(!refreshToken.equals(RefreshTokenValid)){
+        if (!refreshToken.equals(RefreshTokenValid)) {
             log.error("레디스에 저장된 리프레시 토큰이 사용자가 요청한 리프레시 토큰이 다름");
             throw new Exception500("사용할 수 없는 리프레시 토큰입니다. 다시 로그인 해주세요");
         }
@@ -309,7 +309,7 @@ public class UserService {
             String newAccessToken = myJwtProvider.createAccess(memberPS);
             String newRefreshToken = myJwtProvider.createRefresh(memberPS);
             return Pair.of(newAccessToken, newRefreshToken);
-        } catch (Exception e){
+        } catch (Exception e) {
             throw new Exception500("토큰 재발급 실패: " + e.getMessage());
         }
     }

--- a/src/main/java/kr/co/moneybridge/service/UserService.java
+++ b/src/main/java/kr/co/moneybridge/service/UserService.java
@@ -150,7 +150,7 @@ public class UserService {
     @MyLog
     public UserResponse.PasswordOutDTO password(UserRequest.PasswordInDTO passwordInDTO) throws Exception {
         Member memberPS = myMemberUtil.findByEmailWithoutException(passwordInDTO.getEmail(), passwordInDTO.getRole());
-        if(memberPS == null || !memberPS.getName().equals(passwordInDTO.getName())){
+        if(memberPS == null){
             return new UserResponse.PasswordOutDTO();
         }
         String code = sendEmail(passwordInDTO.getEmail());

--- a/src/test/java/kr/co/moneybridge/controller/BackOfficeControllerTest.java
+++ b/src/test/java/kr/co/moneybridge/controller/BackOfficeControllerTest.java
@@ -278,7 +278,7 @@ public class BackOfficeControllerTest {
     public void getMembers() throws Exception {
         // when
         ResultActions resultActions = mvc
-                .perform(get("/admin/members"));
+                .perform(get("/admin/users"));
         String responseBody = resultActions.andReturn().getResponse().getContentAsString();
         System.out.println("테스트 : " + responseBody);
 
@@ -345,7 +345,7 @@ public class BackOfficeControllerTest {
     public void getPBPending() throws Exception {
         // when
         ResultActions resultActions = mvc
-                .perform(get("/admin/pbs"));
+                .perform(get("/admin/pendings"));
         String responseBody = resultActions.andReturn().getResponse().getContentAsString();
         System.out.println("테스트 : " + responseBody);
 

--- a/src/test/java/kr/co/moneybridge/controller/BackOfficeControllerUnitTest.java
+++ b/src/test/java/kr/co/moneybridge/controller/BackOfficeControllerUnitTest.java
@@ -274,10 +274,10 @@ public class BackOfficeControllerUnitTest extends MockDummyEntity {
         Page<User> userPG = new PageImpl<>(Arrays.asList(user));
 
         // stub
-        Mockito.when(backOfficeService.getMembers(any(), any())).thenReturn(new PageDTO<>(userList, userPG, User.class));
+        Mockito.when(backOfficeService.getUsers(any())).thenReturn(new PageDTO<>(userList, userPG, User.class));
 
         // When
-        ResultActions resultActions = mvc.perform(get("/admin/members"));
+        ResultActions resultActions = mvc.perform(get("/admin/users"));
 
         // Then
         resultActions.andExpect(status().isOk());
@@ -332,7 +332,7 @@ public class BackOfficeControllerUnitTest extends MockDummyEntity {
         Mockito.when(backOfficeService.getPBPending(any())).thenReturn(pageDTO);
 
         // When
-        ResultActions resultActions = mvc.perform(get("/admin/pbs"));
+        ResultActions resultActions = mvc.perform(get("/admin/pendings"));
 
         // Then
         resultActions.andExpect(status().isOk());

--- a/src/test/java/kr/co/moneybridge/controller/UserControllerTest.java
+++ b/src/test/java/kr/co/moneybridge/controller/UserControllerTest.java
@@ -277,7 +277,6 @@ public class UserControllerTest {
         // given
         UserRequest.EmailFindInDTO emailFindInDTO = new UserRequest.EmailFindInDTO();
         emailFindInDTO.setRole(Role.USER);
-        emailFindInDTO.setName("김비밀");
         emailFindInDTO.setPhoneNumber("01012345678");
         String requestBody = om.writeValueAsString(emailFindInDTO);
 
@@ -290,9 +289,7 @@ public class UserControllerTest {
         // then
         resultActions.andExpect(jsonPath("$.status").value(200));
         resultActions.andExpect(jsonPath("$.msg").value("ok"));
-        resultActions.andExpect(jsonPath("$.data[0].name").value("김비밀"));
         resultActions.andExpect(jsonPath("$.data[0].phoneNumber").value("01012345678"));
-        resultActions.andExpect(jsonPath("$.data[0].email").value("jisu31484@naver.com"));
     }
 
     @DisplayName("비밀번호 찾기시 이메일 인증 성공")
@@ -302,7 +299,6 @@ public class UserControllerTest {
         // given
         UserRequest.PasswordInDTO passwordInDTO = new UserRequest.PasswordInDTO();
         passwordInDTO.setRole(Role.USER);
-        passwordInDTO.setName("김비밀");
         passwordInDTO.setEmail("jisu31484@naver.com");
         String requestBody = om.writeValueAsString(passwordInDTO);
 

--- a/src/test/java/kr/co/moneybridge/controller/UserControllerUnitTest.java
+++ b/src/test/java/kr/co/moneybridge/controller/UserControllerUnitTest.java
@@ -224,7 +224,6 @@ public class UserControllerUnitTest extends MockDummyEntity {
         // Given
         UserRequest.EmailFindInDTO emailFindInDTO = new UserRequest.EmailFindInDTO();
         emailFindInDTO.setRole(Role.USER);
-        emailFindInDTO.setName("김투자");
         emailFindInDTO.setPhoneNumber("01012345678");
         String requestBody = om.writeValueAsString(emailFindInDTO);
 
@@ -252,7 +251,6 @@ public class UserControllerUnitTest extends MockDummyEntity {
         // Given
         UserRequest.PasswordInDTO passwordInDTO = new UserRequest.PasswordInDTO();
         passwordInDTO.setRole(Role.USER);
-        passwordInDTO.setName("lee");
         passwordInDTO.setEmail("jisu31484@naver.com");
         String requestBody = om.writeValueAsString(passwordInDTO);
 

--- a/src/test/java/kr/co/moneybridge/core/util/MyMemberUtilTest.java
+++ b/src/test/java/kr/co/moneybridge/core/util/MyMemberUtilTest.java
@@ -124,10 +124,10 @@ public class MyMemberUtilTest extends MockDummyEntity {
         String phoneNumber = "01012345678";
 
         // stub
-        when(pbRepository.findByNameAndPhoneNumber(any(), any())).thenReturn(Arrays.asList(pb));
+        when(pbRepository.findByPhoneNumber(any())).thenReturn(Arrays.asList(pb));
 
         // when
-        List<Member> members = myMemberUtil.findByNameAndPhoneNumberWithoutException(name, phoneNumber, Role.PB);
+        List<Member> members = myMemberUtil.findByPhoneNumberWithoutException(phoneNumber, Role.PB);
 
         // then
         Assertions.assertThat(members.get(0)).isEqualTo(pb);
@@ -141,10 +141,10 @@ public class MyMemberUtilTest extends MockDummyEntity {
         String phoneNumber = "01012345678";
 
         // stub
-        when(userRepository.findByNameAndPhoneNumber(any(), any())).thenReturn(Arrays.asList(user));
+        when(userRepository.findByPhoneNumber(any())).thenReturn(Arrays.asList(user));
 
         // when
-        List<Member> members = myMemberUtil.findByNameAndPhoneNumberWithoutException(name, phoneNumber, Role.USER);
+        List<Member> members = myMemberUtil.findByPhoneNumberWithoutException(phoneNumber, Role.USER);
 
         // then
         Assertions.assertThat(members.get(0)).isEqualTo(user);

--- a/src/test/java/kr/co/moneybridge/model/pb/PBRepositoryTest.java
+++ b/src/test/java/kr/co/moneybridge/model/pb/PBRepositoryTest.java
@@ -249,7 +249,7 @@ public class PBRepositoryTest extends DummyEntity {
         String phoneNumber = "01012345678";
 
         // when
-        List<PB> pbPSs = pbRepository.findByNameAndPhoneNumber(name, phoneNumber);
+        List<PB> pbPSs = pbRepository.findByPhoneNumber(phoneNumber);
         PB pbPS = pbPSs.get(0);
 
         // then

--- a/src/test/java/kr/co/moneybridge/model/user/UserRepositoryTest.java
+++ b/src/test/java/kr/co/moneybridge/model/user/UserRepositoryTest.java
@@ -86,7 +86,7 @@ public class UserRepositoryTest extends DummyEntity {
         String phoneNumber = "01012345678";
 
         // when
-        List<User> userPSs = userRepository.findByNameAndPhoneNumber(name, phoneNumber);
+        List<User> userPSs = userRepository.findByPhoneNumber(phoneNumber);
         User userPS = userPSs.get(0);
 
         // then

--- a/src/test/java/kr/co/moneybridge/service/BackOfficeServiceTest.java
+++ b/src/test/java/kr/co/moneybridge/service/BackOfficeServiceTest.java
@@ -5,6 +5,7 @@ import kr.co.moneybridge.core.util.MyMemberUtil;
 import kr.co.moneybridge.core.util.MyMsgUtil;
 import kr.co.moneybridge.dto.PageDTO;
 import kr.co.moneybridge.dto.backOffice.BackOfficeResponse;
+import kr.co.moneybridge.dto.reservation.ReservationResponse;
 import kr.co.moneybridge.model.Role;
 import kr.co.moneybridge.model.backoffice.FrequentQuestion;
 import kr.co.moneybridge.model.backoffice.FrequentQuestionRepository;
@@ -260,38 +261,40 @@ class BackOfficeServiceTest extends MockDummyEntity {
 
     @Test
     @DisplayName("회원(PB) 리스트 가져오기")
-    void getMembersPB() {
+    void getPBs() {
         // given
         Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "id"));
         Company company = newMockCompany(1L, "미래에셋증권");
         Branch branch = newMockBranch(1L, company, 1);
         PB pb = newMockPB(1L, "pblee", branch);
-        Page<PB> pbPG = new PageImpl<>(Arrays.asList(pb));
-        String type = "pb";
+        Page<BackOfficeResponse.PBOutDTO> pbPG = new PageImpl<>(new ArrayList<>(Arrays.asList(
+                new BackOfficeResponse.PBOutDTO(pb, branch)
+        )));
 
         // stub
-        when(pbRepository.findAllByStatus(any(), any())).thenReturn(pbPG);
+        when(pbRepository.findPagesByStatus(any(), any())).thenReturn(pbPG);
 
         // when
-        PageDTO<BackOfficeResponse.MemberOutDTO> pageDTO = backOfficeService.getMembers(type, pageable);
+        PageDTO<BackOfficeResponse.PBOutDTO> pageDTO = backOfficeService.getPBs(pageable);
 
         // then
         assertThat(pageDTO.getList().get(0).getId()).isEqualTo(1);
         assertThat(pageDTO.getList().get(0).getEmail()).isEqualTo("pblee@nate.com");
         assertThat(pageDTO.getList().get(0).getName()).isEqualTo("pblee");
         assertThat(pageDTO.getList().get(0).getPhoneNumber()).isEqualTo("01012345678");
+        assertThat(pageDTO.getList().get(0).getBranchName()).isEqualTo("미래에셋증권 여의도점");
         assertThat(pageDTO.getTotalElements()).isEqualTo(1);
         assertThat(pageDTO.getTotalPages()).isEqualTo(1);
         assertThat(pageDTO.getCurPage()).isEqualTo(0);
         assertThat(pageDTO.getFirst()).isEqualTo(true);
         assertThat(pageDTO.getLast()).isEqualTo(true);
         assertThat(pageDTO.getEmpty()).isEqualTo(false);
-        Mockito.verify(pbRepository, Mockito.times(1)).findAllByStatus(any(), any());
+        Mockito.verify(pbRepository, Mockito.times(1)).findPagesByStatus(any(), any());
     }
 
     @Test
     @DisplayName("회원(투자자) 리스트 가져오기")
-    void getMembersUser() {
+    void getUsers() {
         // given
         Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "id"));
         User user = newMockUser(1L, "user");
@@ -302,7 +305,7 @@ class BackOfficeServiceTest extends MockDummyEntity {
         when(userRepository.findAll(pageable)).thenReturn(userPG);
 
         // when
-        PageDTO<BackOfficeResponse.MemberOutDTO> pageDTO = backOfficeService.getMembers(type, pageable);
+        PageDTO<BackOfficeResponse.UserOutDTO> pageDTO = backOfficeService.getUsers(pageable);
 
         // then
         assertThat(pageDTO.getList().get(0).getId()).isEqualTo(1);

--- a/src/test/java/kr/co/moneybridge/service/UserServiceTest.java
+++ b/src/test/java/kr/co/moneybridge/service/UserServiceTest.java
@@ -250,10 +250,9 @@ public class UserServiceTest extends MockDummyEntity {
         // given
         UserRequest.EmailFindInDTO emailFindInDTO = new UserRequest.EmailFindInDTO();
         emailFindInDTO.setRole(Role.USER);
-        emailFindInDTO.setName("lee");
         emailFindInDTO.setPhoneNumber("01012345678");
 
-        when(myMemberUtil.findByNameAndPhoneNumberWithoutException(emailFindInDTO.getName(), emailFindInDTO.getPhoneNumber(),
+        when(myMemberUtil.findByPhoneNumberWithoutException(emailFindInDTO.getPhoneNumber(),
                 emailFindInDTO.getRole())).thenReturn(Arrays.asList(newMockUser(1L, "lee")));
 
         // when
@@ -271,7 +270,6 @@ public class UserServiceTest extends MockDummyEntity {
         String email = "lee@nate.com";
         UserRequest.PasswordInDTO passwordInDTO = new UserRequest.PasswordInDTO();
         passwordInDTO.setRole(Role.USER);
-        passwordInDTO.setName("lee");
         passwordInDTO.setEmail(email);
 
         when(myMemberUtil.findByEmailWithoutException(passwordInDTO.getEmail(), passwordInDTO.getRole()))


### PR DESCRIPTION
## Motivation

- 비밀번호 찾기 Request Body에서 이름 변수 삭제
- 이메일 찾기 실행시 이름 입력이 필요없도록 수정
- 백오피스 회원 관리 페이지 조회 API를 2개로 분리
- 휴대폰 번호 중복 체크 기능 구현
- PB 리스트 조회시 상담 및 후기 갯수 표시 관련 코드 수정